### PR TITLE
Brew upgrade no longer uses the `--all` option

### DIFF
--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -210,4 +210,4 @@ alias dbmd='spring rake db:migrate:down'
 alias dbmu='spring rake db:migrate:up'
 
 # Homebrew
-alias brewu='brew update  && brew upgrade --all && brew cleanup && brew prune && brew doctor'
+alias brewu='brew update  && brew upgrade && brew cleanup && brew prune && brew doctor'


### PR DESCRIPTION
According to Homebrew/brew#1202, the `--all` flag for `brew upgrade` is no longer required.